### PR TITLE
fix hang due to powerdown of hts221 sensor

### DIFF
--- a/src/MKRENV.cpp
+++ b/src/MKRENV.cpp
@@ -86,8 +86,8 @@ int ENVClass::begin()
 
   readHTS221Calibration();
 
-  // enable HTS221
-  i2cWrite(HTS221_ADDRESS, HTS221_CTRL1_REG, 0x80);
+  // turn on the HTS221 and enable Block Data Update
+  i2cWrite(HTS221_ADDRESS, HTS221_CTRL1_REG, 0x84);
 
   // configure VEML6075 for 100 ms
   i2cWriteWord(VEML6075_ADDRESS, VEML6075_UV_CONF_REG, 0x0010);
@@ -111,6 +111,9 @@ void ENVClass::end()
 
 float ENVClass::readTemperature(int units)
 {
+  // Wait for ONE_SHOT bit to be cleared by the hardware
+  while (i2cRead(HTS221_ADDRESS, HTS221_CTRL2_REG) & 0x01);
+
   // trigger one shot
   i2cWrite(HTS221_ADDRESS, HTS221_CTRL2_REG, 0x01);
 
@@ -131,6 +134,9 @@ float ENVClass::readTemperature(int units)
 
 float ENVClass::readHumidity()
 {
+  //Wait for ONE_SHOT bit to be cleared by the hardware
+  while (i2cRead(HTS221_ADDRESS, HTS221_CTRL2_REG) & 0x01);
+
   // trigger one shot
   i2cWrite(HTS221_ADDRESS, HTS221_CTRL2_REG, 0x01);
 


### PR DESCRIPTION
Introducing a delay before the power off of the hts in the end function the seems that  allow to fix the issue due a power cycle of the module in loop.

this change seems that allow to power down the sensor without generate the issue

the test sketch is:

```c++
#include <SPI.h>
#include <MKRENV.h>
#include <ArduinoLowPower.h>

int counter = 0;

void setup() {
  pinMode(0, OUTPUT);
    pinMode(1, OUTPUT);
}

void loop() {
  digitalWrite(1, LOW);
  if (!ENV.begin()) { 
      digitalWrite(1, HIGH);
  }
  float celsius = ENV.readTemperature();
  ENV.end();

  

  if (celsius > 0) {
    digitalWrite(0, HIGH);
    delay(1000);

    celsius = 0;
  }

  digitalWrite(0, LOW);
  delay(1000);  



//LowPower.sleep(1000);
}
```

with @facchinm  have also check that the delay could be reduce to 50, we have choose 80 to give  a higher tollerance.

cc/ @sandeepmistry @facchinm please make test, i have tested on wifi1010 + MKRENV shield

i'll try to take a look to the datasheet to check the register and sensor operation to see if compliant whit this change.

This change should be also ported on https://github.com/arduino-libraries/Arduino_HTS221/tree/master/src
