### PR TITLE
Restore correct register value on HTS221 shutdown

### DIFF
--- a/src/MKRENV.cpp
+++ b/src/MKRENV.cpp
@@ -98,6 +98,9 @@ void ENVClass::end()
   // shutdown VEML6075
   i2cWriteWord(VEML6075_ADDRESS, VEML6075_UV_CONF_REG, 0x0001);
 
+  // refresh the content of HTS221's internal registers via BOOT bit
+  i2cWrite(HTS221_ADDRESS, HTS221_CTRL2_REG, 0x80);
+
   // disable HTS221
   i2cWrite(HTS221_ADDRESS, HTS221_CTRL1_REG, 0x00);
 


### PR DESCRIPTION
Fixes #13

The test sketch from #13 now works except that after deep sleep the Serial connection doesn't come up again. Seems to be a different issues though. The sensor reading doesn't hang any longer though.

BOOT Bit explained here: 
https://www.st.com/resource/en/datasheet/hts221.pdf Page 23