### PR TITLE
Cicerone MKR host board compatibility fix

### DIFF
--- a/src/MKRENV.cpp
+++ b/src/MKRENV.cpp
@@ -82,7 +82,9 @@ int ENVClass::begin()
   if (i2cReadWord(VEML6075_ADDRESS, VEML6075_ID_REG) != 0x0026) {
     _isv2 = true;
   }
-
+  
+  delay(1); 
+  
   readHTS221Calibration();
 
   // turn on the HTS221 and enable Block Data Update


### PR DESCRIPTION
Introducing the delay fixes the humidity sensor calibration problems that the Cicerone MKR board faces when paired with MKR ENV R2 shield.
Before this modification, the humidity sensor would display values of 90% or more, sometimes even over 100% (Only when using the pair Cicerone MKR and MKR ENV R2). Moreover, the humidity value would decrease as the ambient humidity increased.
After the fix, the humidity value is reported correctly. Finally, the introduction of this delay does not influence the calibration while using other MKR hosts (tested with MKR NB IoT board).